### PR TITLE
Tell ReSharper the shadow copy cache location

### DIFF
--- a/resharper/src/xunitcontrib.runner.resharper.runner/TestRunner.cs
+++ b/resharper/src/xunitcontrib.runner.resharper.runner/TestRunner.cs
@@ -1,11 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using JetBrains.ReSharper.TaskRunnerFramework;
-using JetBrains.Util;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,35 +21,26 @@ namespace XunitContrib.Runner.ReSharper.RemoteRunner
 
         public void Run(XunitTestAssemblyTask assemblyTask, TaskProvider taskProvider)
         {
-            //MessageBox.ShowError("foo");
-
             var priorCurrentDirectory = Environment.CurrentDirectory;
             try
             {
                 // Use the assembly in the folder that the user has specified, or, if not, use the assembly location
                 var assemblyFolder = GetAssemblyFolder(configuration, assemblyTask);
                 var assemblyPath = Path.Combine(assemblyFolder, GetFileName(assemblyTask.AssemblyLocation));
+                var configFile = GetConfigFile(assemblyPath);
+                var shadowCopyPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
                 Environment.CurrentDirectory = assemblyFolder;
 
-                // If we just pass null for the config file, the AppDomain will load {assembly}.config if it exists,
-                // or use the config file of this app domain, which will usually be JetBrains.ReSharper.TaskRunner.*.exe.config.
-                // If we specify the name directly, it will just use it, or have no configuration, with no fallback.
-                // This is good because it stops the TaskRunner.exe config leaking into your tests. For example, that
-                // file redirects all ReSharper assemblies to the current version. When the default AppDomain loads our
-                // code, the assemblies are successfully redirected, and we use the latest version. If the new AppDomain
-                // uses the same redirects, and the test assembly references resharper assemblies (e.g. xunitcontrib tests!)
-                // the redirects are applied, but the new AppDomain can't find the newer assemblies, and throws
-                var configFile = assemblyPath + ".config";
+                // Tell ReSharper about the shadow copy path, so it can clean up after abort. Xunit (1+2) will try and
+                // clean up at the end of the run
+                server.SetTempFolderPath(shadowCopyPath);
 
-                //MessageBox.ShowError("Pants");
-
-                // TODO: Source information provider?
-                using (var controller = new XunitFrontController(assemblyPath, configFile, configuration.ShadowCopy))
+                // Pass in a null source information provider. We don't need or use it, so make sure xunit doesn't
+                // create one for us, dragging in DIA and creating a new AppDomain. Let's keep things lightweight
+                using (var controller = new XunitFrontController(assemblyPath, configFile, configuration.ShadowCopy,
+                    shadowCopyPath, new NullSourceInformationProvider()))
                 {
-                    // TODO: How to get the temp folder now?
-                    //SetTempFolderPath(executorWrapper);
-
                     var testCases = GetTestCases(controller, taskProvider);
 
                     var run = new XunitTestRun(server, controller, taskProvider);
@@ -69,6 +57,19 @@ namespace XunitContrib.Runner.ReSharper.RemoteRunner
             }
         }
 
+        private static string GetConfigFile(string assemblyPath)
+        {
+            // If we just pass null for the config file, the AppDomain will load {assembly}.config if it exists,
+            // or use the config file of this app domain, which will usually be JetBrains.ReSharper.TaskRunner.*.exe.config.
+            // If we specify the name directly, it will just use it, or have no configuration, with no fallback.
+            // This is good because it stops the TaskRunner.exe config leaking into your tests. For example, that
+            // file redirects all ReSharper assemblies to the current version. When the default AppDomain loads our
+            // code, the assemblies are successfully redirected, and we use the latest version. If the new AppDomain
+            // uses the same redirects, and the test assembly references resharper assemblies (e.g. xunitcontrib tests!)
+            // the redirects are applied, but the new AppDomain can't find the newer assemblies, and throws
+            return assemblyPath + ".config";
+        }
+
         private IEnumerable<ITestCase> GetTestCases(ITestFrameworkDiscoverer discoverer, TaskProvider taskProvider)
         {
             var visitor = new TestDiscoveryVisitor();
@@ -76,28 +77,6 @@ namespace XunitContrib.Runner.ReSharper.RemoteRunner
             visitor.Finished.WaitOne();
             return visitor.TestCases.Where(c => taskProvider.GetClassTask(c.TestMethod.TestClass.Class.Name) != null);
         }
-
-        // TODO: This was cheeky. Let's find a Better Way
-        // Tell ReSharper the cache folder being used for shadow copy, so that if
-        // someone kills this process (e.g. user aborts), ReSharper can delete it.
-        // xunit doesn't expose this information, so we'll grab it via (sorry) reflection
-        //private void SetTempFolderPath(ExecutorWrapper executorWrapper)
-        //{
-        //    if (!configuration.ShadowCopy)
-        //        return;
-
-        //    var fieldInfo = executorWrapper.GetType().GetField("appDomain", BindingFlags.NonPublic | BindingFlags.Instance);
-        //    if (fieldInfo == null)
-        //        throw new InvalidOperationException("Expected ExecutorWrapped to contain private field \"appDomain\"");
-
-        //    var appDomain = fieldInfo.GetValue(executorWrapper) as AppDomain;
-        //    if (appDomain != null)
-        //    {
-        //        var cachePath = appDomain.SetupInformation.CachePath;
-        //        if (!string.IsNullOrEmpty(cachePath))
-        //            server.SetTempFolderPath(cachePath);
-        //    }
-        //}
 
         private static string GetAssemblyFolder(TaskExecutorConfiguration config, XunitTestAssemblyTask assemblyTask)
         {


### PR DESCRIPTION
Tell xunit where to put the shadow copy, and tell ReSharper where that
is so that it will get cleaned up in case of abort. Also, now uses
NullSourceInformationProvider to prevent an extra AppDomain being
created
