### PR TITLE
Escape control chars in strings

### DIFF
--- a/resharper/src/xunitcontrib.runner.resharper.provider/UnitTestElementFactory.cs
+++ b/resharper/src/xunitcontrib.runner.resharper.provider/UnitTestElementFactory.cs
@@ -7,6 +7,7 @@ using JetBrains.ReSharper.UnitTestFramework;
 using JetBrains.ReSharper.UnitTestFramework.Elements;
 using Xunit.Sdk;
 using JetBrains.Util;
+using XunitContrib.Runner.ReSharper.RemoteRunner;
 
 namespace XunitContrib.Runner.ReSharper.UnitTestProvider
 {
@@ -143,7 +144,8 @@ namespace XunitContrib.Runner.ReSharper.UnitTestProvider
         private static string GetTestTheoryShortName(string theoryName, XunitTestMethodElement methodElement)
         {
             var prefix = methodElement.TypeName.FullName + ".";
-            return theoryName.StartsWith(prefix) ? theoryName.Substring(prefix.Length) : theoryName;
+            var name = theoryName.StartsWith(prefix) ? theoryName.Substring(prefix.Length) : theoryName;
+            return DisplayNameUtil.Escape(name);
         }
 
         private static string GetTestTheoryId(XunitTestMethodElement methodElement, string shortName)

--- a/resharper/src/xunitcontrib.runner.resharper.runner/DisplayNameUtil.cs
+++ b/resharper/src/xunitcontrib.runner.resharper.runner/DisplayNameUtil.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Text;
+
+namespace XunitContrib.Runner.ReSharper.RemoteRunner
+{
+    public class DisplayNameUtil
+    {
+        public static string Escape(string name)
+        {
+            var sb = new StringBuilder();
+            foreach (var c in name)
+                sb.Append(EscapeControlChar(c));
+
+            return sb.ToString();
+        }
+
+        private static string EscapeControlChar(char c)
+        {
+            switch (c)
+            {
+                case '\0':
+                    return "\\0";
+                case '\a':
+                    return "\\a";
+                case '\b':
+                    return "\\b";
+                case '\f':
+                    return "\\f";
+                case '\n':
+                    return "\\n";
+                case '\r':
+                    return "\\r";
+                case '\t':
+                    return "\\t";
+                case '\v':
+                    return "\\v";
+
+                case '\x0085':
+                case '\x2028':
+                case '\x2029':
+                    return string.Format("\\x{0:X4}", (ushort)c);
+
+                default:
+                    return char.IsControl(c) || (ushort)c > 128
+                             ? String.Format("\\x{0:X4}", (ushort)c)
+                             : c.ToString();
+            }
+        }
+    }
+}

--- a/resharper/src/xunitcontrib.runner.resharper.runner/TaskProvider.cs
+++ b/resharper/src/xunitcontrib.runner.resharper.runner/TaskProvider.cs
@@ -102,7 +102,8 @@ namespace XunitContrib.Runner.ReSharper.RemoteRunner
         private static string GetTheoryShortName(string name, string type)
         {
             var prefix = type + ".";
-            return name.StartsWith(prefix) ? name.Substring(prefix.Length) : name;
+            var shortName = name.StartsWith(prefix) ? name.Substring(prefix.Length) : name;
+            return DisplayNameUtil.Escape(shortName);
         }
 
         private static bool IsTheory(string name, string type, string method)

--- a/resharper/src/xunitcontrib.runner.resharper.runner/xunitcontrib.runner.resharper.runner.8.2.csproj
+++ b/resharper/src/xunitcontrib.runner.resharper.runner/xunitcontrib.runner.resharper.runner.8.2.csproj
@@ -55,6 +55,7 @@
       <Link>Properties\ProductInfo.ReSharper.8.2.cs</Link>
     </Compile>
     <Compile Include="AttributeNames.cs" />
+    <Compile Include="DisplayNameUtil.cs" />
     <Compile Include="ISetTempFolderPathStrategy.cs" />
     <Compile Include="ISimpleClientController.cs" />
     <Compile Include="ISimpleRemoteTaskServer.cs" />

--- a/resharper/test/data/Runner/Gold/EscapedDataAttributeStrings.cs
+++ b/resharper/test/data/Runner/Gold/EscapedDataAttributeStrings.cs
@@ -1,0 +1,19 @@
+using Xunit;
+using Xunit.Extensions;
+
+namespace Foo
+{
+    public class PassingTheory
+    {
+        [Theory]
+        [InlineData("$ \\ \b \f \n \r \t \v")]
+        public void TestMethod(string value)
+        {
+        }
+    }
+}
+
+// xunit2 doesn't define Xunit.Extensions
+namespace Xunit.Extensions
+{
+}

--- a/resharper/test/data/Runner/Gold/EscapedDataAttributeStrings.xunit1.dll.gold
+++ b/resharper/test/data/Runner/Gold/EscapedDataAttributeStrings.xunit1.dll.gold
@@ -1,0 +1,14 @@
+﻿<task-start />
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" /></task-start>
+<cache-folder />
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" Explicitly="False" /></task-start>
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" Explicitly="False" Dynamic="False" /></task-start>
+<task-create><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \x8 \xC \n \r \t \xB&quot;)" /></task-create>
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \x8 \xC \n \r \t \xB&quot;)" /></task-start>
+<task-duration><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \x8 \xC \n \r \t \xB&quot;)" /></task-duration>
+<task-finish result="Success"><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \x8 \xC \n \r \t \xB&quot;)" /><message /></task-finish>
+<task-duration><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" Explicitly="False" Dynamic="False" /></task-duration>
+<task-finish result="Success"><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" Explicitly="False" Dynamic="False" /><message /></task-finish>
+<task-duration><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" Explicitly="False" /></task-duration>
+<task-finish result="Success"><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" Explicitly="False" /><message /></task-finish>
+<task-finish result="Success" />

--- a/resharper/test/data/Runner/Gold/EscapedDataAttributeStrings.xunit2.dll.gold
+++ b/resharper/test/data/Runner/Gold/EscapedDataAttributeStrings.xunit2.dll.gold
@@ -1,0 +1,14 @@
+﻿<task-start />
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" /></task-start>
+<cache-folder />
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" Explicitly="False" /></task-start>
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" Explicitly="False" Dynamic="False" /></task-start>
+<task-create><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \b \f \n \r \t \v&quot;)" /></task-create>
+<task-start><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \b \f \n \r \t \v&quot;)" /></task-start>
+<task-duration><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \b \f \n \r \t \v&quot;)" /></task-duration>
+<task-finish result="Success"><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" TheoryName="TestMethod(value: &quot;$ \ \b \f \n \r \t \v&quot;)" /><message /></task-finish>
+<task-duration><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" Explicitly="False" Dynamic="False" /></task-duration>
+<task-finish result="Success"><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" MethodName="TestMethod" Explicitly="False" Dynamic="False" /><message /></task-finish>
+<task-duration><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" Explicitly="False" /></task-duration>
+<task-finish result="Success"><task runnerID="xUnit" ProjectId="697F5F53-AEB2-4284-AA79-90E7368C55E6" TypeName="Foo.PassingTheory" Explicitly="False" /><message /></task-finish>
+<task-finish result="Success" />

--- a/resharper/test/src/tests/AcceptanceTests/Runner/OrderedFactGoldTests.cs
+++ b/resharper/test/src/tests/AcceptanceTests/Runner/OrderedFactGoldTests.cs
@@ -46,5 +46,11 @@ namespace XunitContrib.Runner.ReSharper.Tests.AcceptanceTests.Runner
             // TODO: This misses a test to continue running next class. Ordering.
             DoOneTestWithStrictOrdering("AmbiguouslyNamedTestMethods");
         }
+
+        [Test]
+        public void TestEscapedStringsInDataAttributes()
+        {
+            DoOneTestWithStrictOrdering("EscapedDataAttributeStrings");
+        }
     }
 }


### PR DESCRIPTION
Causes issues with xml serialisation of messages between ReSharper and
the external test runner. This was already handled by xunit1, since it
used xml to serialise between AppDomains. Serialises interfaces and raw
strings now, so no longer needs to escape strings.

Fixes #10
